### PR TITLE
Fix url host

### DIFF
--- a/config/bigtuna.yml.sample
+++ b/config/bigtuna.yml.sample
@@ -1,3 +1,4 @@
 # production:
 #   read_only: true # default: false
 #   github_secure: "think_of_secure_token" # default: nil
+#   url_host: "ci.yoursite.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,13 @@ BigTuna::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = YAML.load_file("config/email.yml")[Rails.env]
-  config.action_mailer.default_url_options = { :host => 'ci.appelier.com' }
+
+  bigtuna_config = YAML.load_file("config/bigtuna.yml")[Rails.env]
+  if !bigtuna_config['url_host']
+    raise "No url_host set in config/bigtuna.yml. Notification links will not work."
+  end
+
+  config.action_mailer.default_url_options = { :host => bigtuna_config['url_host'] }
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Currently in production.rb, `config.action_mailer.default_url_options` is hard-coded to appelier.com. This patch fixes that, and forces the user to set a config variable in bigtuna.yml.
