### PR TITLE
Fix github private build

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -15,7 +15,8 @@ class HooksController < ApplicationController
     branch = payload["ref"].split("/").last
     url = payload["repository"]["url"]
     public_source = url.gsub(/^https:\/\//, "git://") + ".git"
-    private_source = url.gsub(/^https:\/\//, "git://git@") + ".git"
+    private_source = url.gsub(/^https:\/\//, "git@").
+                         gsub(/github.com\//, "github.com:") + ".git"
 
     project = Project.where(["(vcs_source = ? or vcs_source = ?) AND (vcs_branch = ?)",
                               public_source, private_source, branch]).first

--- a/test/integration/autobuild_test.rb
+++ b/test/integration/autobuild_test.rb
@@ -38,7 +38,7 @@ class AutobuildTest < ActionController::IntegrationTest
 
   test "github post for a private repo will build correctly" do
     project = github_project(:name => 'seotool', :vcs_branch => 'master',
-                             :vcs_source => "git://git@github.com/company/secretrepo.git")
+                             :vcs_source => "git@github.com:company/secretrepo.git")
     old_token = BigTuna.config['github_secure']
     begin
       BigTuna.config["github_secure"] = "mytoken"
@@ -93,9 +93,9 @@ class AutobuildTest < ActionController::IntegrationTest
   end
 
   def github_payload(project)
-    url = project.vcs_source.gsub(/^git:\/\//, "https://").
-        gsub(/\.git$/, "").
-        gsub(/git@/, '')
+    match = project.vcs_source.match(/github\.com(?:\/|:)(.+)$/)
+    name = match[1].strip.gsub(/\.git$/, '')
+    url = "https://github.com/#{name}"
 
     payload = {
       "ref" => "refs/heads/#{project.vcs_branch}",


### PR DESCRIPTION
Any private projects on GitHub do not build correctly with the secure_token notifier. This patch will fix that!
