### PR TITLE
Fix for LoadError in config/initializers/big_tuna.rb

### DIFF
--- a/config/initializers/big_tuna.rb
+++ b/config/initializers/big_tuna.rb
@@ -35,5 +35,5 @@ module BigTuna
   end
 end
 
-Dir[File.join("extras", "big_tuna", "vcs", "*.rb")].each { |vcs| require_dependency(vcs) }
-Dir[File.join("extras", "big_tuna", "hooks", "*.rb")].each { |hook| require_dependency(hook) }
+Dir[File.join(Rails.root, "extras", "big_tuna", "vcs", "*.rb")].each { |vcs| require_dependency(vcs) }
+Dir[File.join(Rails.root, "extras", "big_tuna", "hooks", "*.rb")].each { |hook| require_dependency(hook) }


### PR DESCRIPTION
Hi!

I tried to upgrade from an older to the latest version of BigTuna (the master branch). I got a `LoadError` in `config/initializers/big_tuna.rb`, I fixed it in the attached commit by prepending Rails.root causing `require_dependency` to get the full file paths. The server is running Ubuntu, Ruby 1.9.2 through RVM, nginx and Phusion Passenger. I have attached a screenshot of the error.

![Screenshot](http://i.imgur.com/GVUPF.png)
