### PR TITLE
Refactoring runner/output.rb

### DIFF
--- a/lib/big_tuna/runner/output.rb
+++ b/lib/big_tuna/runner/output.rb
@@ -50,10 +50,10 @@ module BigTuna
       
       return if txt.nil?
       
-      lines = txt.split /\r?\n/
+      lines = txt.split /\r?\n/, -1
       
-      # continue from where we left off
-      if @output != [] && @output.last[0] == stream
+      # continue from where we left off?
+      unless @output.empty? || @output.last[0] != stream
         @output.last[1] << lines.shift
       end
       

--- a/test/unit/output_test.rb
+++ b/test/unit/output_test.rb
@@ -37,4 +37,17 @@ class OutputTest < ActiveSupport::TestCase
   end
   
   
+  test 'trailing linebreaks are seperated' do
+    
+    @output.append_stdout "a\n"
+    @output.append_stdout "b"
+    @output.append_stderr 'c'
+    
+    result = @output.finish 0
+    
+    assert_equal result, [[OUT, 'a'],[OUT, 'b'],[ERR,'c']]
+    
+  end
+  
+  
 end


### PR DESCRIPTION
I changed the way that output.rb normalises the sterr and stout - instead of processing the output when it finishes, it appends cleanly along the way.
