### PR TITLE
Github hook improvements

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -13,20 +13,21 @@ class HooksController < ApplicationController
   def github
     payload = JSON.parse(params[:payload])
     branch = payload["ref"].split("/").last
-    url = payload["repository"]["url"]
-    public_source = url.gsub(/^https:\/\//, "git://") + ".git"
-    private_source = url.gsub(/^https:\/\//, "git@").
-                         gsub(/github.com\//, "github.com:") + ".git"
+    github_project_path = payload["repository"]["url"].match( %r{github\.com/(.*)} )[1]
+    search_term = "%github.com_#{github_project_path}.git"
 
-    project = Project.where(["(vcs_source = ? or vcs_source = ?) AND (vcs_branch = ?)",
-                              public_source, private_source, branch]).first
+    projects = Project.where(["vcs_source LIKE ?", search_term]).where(:vcs_branch => branch).all
 
     if BigTuna.github_secure.nil?
       render :text => "github secure token is not set up", :status => 403
-    elsif project and params[:secure] == BigTuna.github_secure
-      trigger_and_respond(project)
+    elsif projects.present? && params[:secure] == BigTuna.github_secure
+      projects.each(&:build!)
+      render :text => "build for the following projects were triggered: " +
+        projects.map(&:name).map(&:inspect).join(', '), :status => 200
+    elsif projects.empty?
+      render :text => "project not found", :status => 404
     else
-      render :text => "invalid secure token", :status => 404
+      render :text => "invalid secure token", :status => 403
     end
   end
 
@@ -60,6 +61,5 @@ class HooksController < ApplicationController
   private
   def trigger_and_respond(project)
     project.build!
-    render :text => "build for %p triggered" % [project.name], :status => 200
   end
 end

--- a/test/integration/autobuild_test.rb
+++ b/test/integration/autobuild_test.rb
@@ -13,68 +13,49 @@ class AutobuildTest < ActionController::IntegrationTest
   test "if github posts hook we look for specified branch to build" do
     project1 = github_project(:name => "obywatelgc", :vcs_branch => "master")
     project2 = github_project(:name => "obywatelgc2", :vcs_branch => "development")
-    old_token = BigTuna.config[:github_secure]
-    begin
-      BigTuna.config[:github_secure] = "mytoken"
-      token = BigTuna.github_secure
+    with_github_token do
       assert_difference("project1.builds.count", +1) do
         assert_difference("project2.builds.count", 0) do
-          post "/hooks/build/github/#{token}", :payload => github_payload(project1)
+          post "/hooks/build/github/#{@token}", :payload => github_payload(project1)
           assert_status_code(200)
           assert response.body.include?("build for \"#{project1.name}\" triggered")
         end
       end
-    ensure
-      BigTuna.config[:github_secure] = old_token
     end
   end
 
   test "github post for a private repo will build correctly" do
     project = github_project(:name => 'seotool', :vcs_branch => 'master',
                              :vcs_source => "git@github.com:company/secretrepo.git")
-    old_token = BigTuna.config[:github_secure]
-    begin
-      BigTuna.config[:github_secure] = "mytoken"
-      token = BigTuna.github_secure
+    with_github_token do
       assert_difference("project.builds.count", +1) do
-        post "/hooks/build/github/#{token}", :payload => github_payload(project)
+        post "/hooks/build/github/#{@token}", :payload => github_payload(project)
         assert_status_code(200)
         assert response.body.include?("build for \"#{project.name}\" triggered")
       end
-    ensure
-      BigTuna.config[:github_secure] = old_token
     end
   end
 
   test "github post with invalid token won't build anything" do
     project1 = github_project(:name => "obywatelgc", :vcs_branch => "master")
     project2 = github_project(:name => "obywatelgc2", :vcs_branch => "development")
-    old_token = BigTuna.config[:github_secure]
-    begin
-      BigTuna.config[:github_secure] = "mytoken"
-      token = BigTuna.github_secure
-      invalid_token = token + "a"
+    with_github_token do
+      invalid_token = @token + "a"
       assert_difference("Build.count", 0) do
         post "/hooks/build/github/#{invalid_token}", :payload => github_payload(project1)
         assert_status_code(404)
         assert response.body.include?("invalid secure token")
       end
-    ensure
-      BigTuna.config[:github_secure] = old_token
     end
   end
 
   test "github token has to be set up" do
     project1 = github_project(:name => "obywatelgc", :vcs_branch => "master")
-    old_token = BigTuna.config[:github_secure]
-    begin
-      BigTuna.config[:github_secure] = nil
+    with_github_token(nil) do
       assert_equal nil, BigTuna.github_secure
       post "/hooks/build/github/4ff", :payload => github_payload(project1)
       assert_status_code(403)
       assert response.body.include?("github secure token is not set up")
-    ensure
-      BigTuna.config[:github_secure] = old_token
     end
   end
 
@@ -85,9 +66,20 @@ class AutobuildTest < ActionController::IntegrationTest
     project
   end
 
+  def with_github_token(token = Array.new(8) { ('a'..'z').to_a.sample }.join)
+    @token = token
+    old_token = BigTuna.config[:github_secure]
+    begin
+      BigTuna.config[:github_secure] = token
+      yield
+    ensure
+      BigTuna.config[:github_secure] = old_token
+      @token = nil
+    end
+  end
+
   def github_payload(project)
-    match = project.vcs_source.match(/github\.com(?:\/|:)(.+)$/)
-    name = match[1].strip.gsub(/\.git$/, '')
+    name = project.vcs_source.match( %r{github\.com[/:](.+)\.git$} )[1]
     url = "https://github.com/#{name}"
 
     payload = {


### PR DESCRIPTION
Improved github hook support as follows:
- refactored tests to remove repetition
- allow multiple projects to be built if they match URL and branch
- handle private https:// urls
- distinct error message if project is not found (404 code)
- return 403 for invalid token instead of 404
