### PR TITLE
Fix project ajax reload

### DIFF
--- a/app/views/builds/_step.html.haml
+++ b/app/views/builds/_step.html.haml
@@ -9,6 +9,6 @@
     %p.command= "$ #{step.command}"
     - if !step.exit_code.nil? and step.has_output?
       - step.all.each do |type, text|
-        - if ((type != BigTuna::Runner::Output::TYPE_STDERR or params[:stderr]) and !text.empty?)
+        - if ((type != BigTuna::Runner::Output::TYPE_STDERR or params[:stderr]) and !text.blank?)
           = strip_shell_colorization(text)
 %br

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,4 +1,5 @@
-= render :partial => 'projects'
+#listing
+  = render :partial => 'projects'
 
 = ajaxReload(projects_path(:format => :js))
 


### PR DESCRIPTION
Embeds the project list in a div#listing, the javascript expects this to be the container when ajax reload is set.
